### PR TITLE
Made SDKs paths non hardcoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ The project source code depends on:
 The project uses following thirt-party libraries:
 
 - **[AMD GPU Services](https://github.com/GPUOpen-LibrariesAndSDKs/AGS_SDK)** - custom vendor extensions to graphics APIs by AMD.
-  - Linked externally. Can compile without it - see macro `USE_AGS`.
+  - You need to obtain your copy and globally define `AMD_AGS_PATH` environment variable. You need at least version 6.0.1.
+  - Can compile without it - see macro `USE_AGS`.
 - **[DirectX 12 Agility SDK](https://devblogs.microsoft.com/directx/directx12agility/)** - latest API to Direct3D, by Microsoft.
   - Directory: Src\ThirdParty\microsoft.direct3d.d3d12.*
 - **[NVAPI](https://developer.nvidia.com/nvapi)** - custom vendor extensions to graphics APIs by Nvidia.
-  - Linked externally. Can compile without it - see macro `USE_NVAPI`.
+  - You need to obtain your copy and globally define `NVIDIA_NVAPI_PATH` environment variable. You need at least version R520.
+  - Can compile without it - see macro `USE_NVAPI`.
 - **[RapidJSON](https://rapidjson.org/)** - a fast JSON parser/generator, by Tencent. License: MIT.
   - Directory: Src\ThirdParty\rapidjson
 - **[Vulkan SDK](https://www.lunarg.com/vulkan-sdk/)**
-  - Linked externally. Can compile without it - see macro `USE_VULKAN`.
+  - You need to install Vulkan SDK on your PC. You need at least version 1.3.216.0.
+  - Can compile without it - see macro `USE_VULKAN`.

--- a/Src/D3d12info.vcxproj
+++ b/Src/D3d12info.vcxproj
@@ -66,15 +66,18 @@
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <DisableSpecificWarnings>4100;4189;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>f:\Libraries\NVAPI\R520-developer;f:\Libraries\AMD\AGS_SDK-6.0.1\ags_lib\inc;c:\VulkanSDK\1.3.216.0\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%NVIDIA_NVAPI_PATH%;%AMD_AGS_PATH%\ags_lib\inc;%VULKAN_SDK%\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>f:\Libraries\NVAPI\R520-developer\amd64;f:\Libraries\AMD\AGS_SDK-6.0.1\ags_lib\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>%NVIDIA_NVAPI_PATH%\amd64;%AMD_AGS_PATH%\ags_lib\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>PostBuildStep.bat $(OutDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -89,7 +92,7 @@
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <DisableSpecificWarnings>4100;4189;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>f:\Libraries\NVAPI\R520-developer;f:\Libraries\AMD\AGS_SDK-6.0.1\ags_lib\inc;c:\VulkanSDK\1.3.216.0\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%NVIDIA_NVAPI_PATH%;%AMD_AGS_PATH%\ags_lib\inc;%VULKAN_SDK%\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -98,8 +101,11 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>f:\Libraries\NVAPI\R520-developer\amd64;f:\Libraries\AMD\AGS_SDK-6.0.1\ags_lib\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>%NVIDIA_NVAPI_PATH%\amd64;%AMD_AGS_PATH%\ags_lib\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>PostBuildStep.bat $(OutDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="AgsData.hpp" />

--- a/Src/PostBuildStep.bat
+++ b/Src/PostBuildStep.bat
@@ -1,0 +1,4 @@
+@echo off
+rem First argument is path to build directory
+rem We need to copy required dll's there
+copy %AMD_AGS_PATH%\ags_lib\lib\amd_ags_x64.dll %1\amd_ags_x64.dll


### PR DESCRIPTION
You'll need to globally define some environment variables, from old hardcoded paths it seems that:
NVIDIA_NVAPI_PATH=f:\Libraries\NVAPI\R520-developer
AMD_AGS_PATH=f:\Libraries\AMD\AGS_SDK-6.0.1
VULKAN_SDK is set by installer, no need to manually set it