### PR TITLE
Updated json output to make it more easily parsable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Options:
   -v --Version         Only print program version information.
   -h --Help            Only print this help (command line syntax).
   -l --List            Only print the list of all adapters.
-  -a --Adapter=<Index> Print details of adapter at specified index (default is the first hardware adapter).
+  -a --Adapter=<Index> Print details of adapter at specified index.
+  -all --AllAdapters   Print details of all (non WARP) adapters (default behavior).
   -j --JSON            Print output in JSON format instead of human-friendly text.
   -f --Formats         Include information about DXGI format capabilities.
   -e --Enums           Include information about all known enums and their values.

--- a/Src/Printing.cpp
+++ b/Src/Printing.cpp
@@ -316,10 +316,8 @@ void PrintHexBytes(const wchar_t* name, const void* data, size_t byteCount)
 void PrintFormat(const wchar_t* name, const wchar_t* format, ...) {
     va_list argList;
     va_start(argList, format);
-    wchar_t value[256];
-    // Parses printf format and parameters from va_list and create wide char
-    // string
-    _vsnwprintf_s(value, ARRAYSIZE(value), format, argList);
+    wchar_t buffer[256];
+    _vsnwprintf_s(buffer, ARRAYSIZE(buffer), format, argList);
     va_end(argList);
-    Print_string(name, value);
+    Print_string(name, buffer);
 }

--- a/Src/Printing.cpp
+++ b/Src/Printing.cpp
@@ -312,3 +312,14 @@ void PrintHexBytes(const wchar_t* name, const void* data, size_t byteCount)
         valStr += std::format(L"{:02X}", *((const uint8_t*)data + i));
     Print_string(name, valStr.c_str());
 }
+
+void PrintFormat(const wchar_t* name, const wchar_t* format, ...) {
+    va_list argList;
+    va_start(argList, format);
+    wchar_t value[256];
+    // Parses printf format and parameters from va_list and create wide char
+    // string
+    _vsnwprintf_s(value, ARRAYSIZE(value), format, argList);
+    va_end(argList);
+    Print_string(name, value);
+}

--- a/Src/Printing.hpp
+++ b/Src/Printing.hpp
@@ -32,3 +32,4 @@ void Print_float(const wchar_t* name, float value, const wchar_t* unit = nullptr
 void PrintEnum(const wchar_t* name, uint32_t value, const EnumItem* enumItems, bool isSigned = false);
 void PrintFlags(const wchar_t* name, uint32_t value, const EnumItem* enumItems);
 void PrintHexBytes(const wchar_t* name, const void* data, size_t byteCount);
+void PrintFormat(const wchar_t* name, const wchar_t* format, ...);

--- a/Src/Utils.cpp
+++ b/Src/Utils.cpp
@@ -207,6 +207,24 @@ void CmdLineParser::RegisterOpt(uint32_t Id, const std::wstring &Opt, bool Param
 	m_LongOpts.push_back(LONG_OPT(Id, Opt, Parameter));
 }
 
+CmdLineParser::RESULT CmdLineParser::ReadNextOpt()
+{
+	RESULT Result = ReadNext();
+	while (Result != RESULT_END && Result != RESULT_ERROR && Result != RESULT_OPT)
+	{
+		Result = ReadNext();
+	}
+
+	if (Result == RESULT_OPT)
+	{
+		if (m_EncounteredOpts.contains(m_LastOptId))
+			return RESULT_ERROR;
+		m_EncounteredOpts.insert(m_LastOptId);
+	}
+
+	return Result;
+}
+
 CmdLineParser::RESULT CmdLineParser::ReadNext()
 {
 	if (m_InsideMultioption)
@@ -472,4 +490,9 @@ uint32_t CmdLineParser::GetOptId()
 const std::wstring & CmdLineParser::GetParameter()
 {
 	return m_LastParameter;
+}
+
+bool CmdLineParser::IsOptEncountered(uint32_t Id)
+{
+	return m_EncounteredOpts.contains(Id);
 }

--- a/Src/Utils.hpp
+++ b/Src/Utils.hpp
@@ -35,10 +35,11 @@ public:
 	
     void RegisterOpt(uint32_t Id, wchar_t Opt, bool Parameter);
 	void RegisterOpt(uint32_t Id, const std::wstring &Opt, bool Parameter);
-	
-    RESULT ReadNext();
+
+	RESULT ReadNextOpt();
 	uint32_t GetOptId();
 	const std::wstring & GetParameter();
+	bool IsOptEncountered(uint32_t Id);
 
 private:
 	struct SHORT_OPT
@@ -65,6 +66,7 @@ private:
 	size_t m_CmdLineLength;
 	size_t m_ArgIndex;
 
+	RESULT ReadNext();
 	bool ReadNextArg(std::wstring *OutArg);
 
 	std::vector<SHORT_OPT> m_ShortOpts;
@@ -78,4 +80,5 @@ private:
 	size_t m_LastArgIndex;
 	uint32_t m_LastOptId;
 	std::wstring m_LastParameter;
+	std::set<uint32_t> m_EncounteredOpts;
 };

--- a/Src/Utils.hpp
+++ b/Src/Utils.hpp
@@ -32,8 +32,8 @@ public:
 
 	CmdLineParser(int argc, wchar_t **argv);
 	CmdLineParser(const wchar_t *CmdLine);
-	
-    void RegisterOpt(uint32_t Id, wchar_t Opt, bool Parameter);
+
+	void RegisterOpt(uint32_t Id, wchar_t Opt, bool Parameter);
 	void RegisterOpt(uint32_t Id, const std::wstring &Opt, bool Parameter);
 
 	RESULT ReadNextOpt();

--- a/Src/pch.hpp
+++ b/Src/pch.hpp
@@ -27,6 +27,8 @@ For more information, see files README.md, LICENSE.txt.
 #include <wrl/client.h> // for ComPtr
 
 #include <vector>
+#include <array>
+#include <set>
 #include <string>
 #include <exception>
 #include <format>


### PR DESCRIPTION
- Added option to output info from all adapters
- Implemented querying of D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY
- Refactored header structure
- Changed OS version output
  - Removed unused or irrelevant parameters (service pack related parameters, product type related parameters)
  - Changed formatting to output version in human readable format
- Removed reporting of DXGI_FEATURE_PRESENT_ALLOW_TEARING
	- It's an OS capability. It was introduced before Agility SDK support, so D3d12info won't be useful on systems that has it set to false anyway.

Example output before PR:
[2.2.0.txt](https://github.com/sawickiap/D3d12info/files/13774002/2.2.0.txt)
[2.2.0.json](https://github.com/sawickiap/D3d12info/files/13774005/2.2.0.json)
Example output after PR:
[PR.txt](https://github.com/sawickiap/D3d12info/files/13774001/PR.txt)
[PR.json](https://github.com/sawickiap/D3d12info/files/13774004/PR.json)
[PR_all.txt](https://github.com/sawickiap/D3d12info/files/13773999/PR_all.txt)
[PR_all.json](https://github.com/sawickiap/D3d12info/files/13774003/PR_all.json)
