### PR TITLE
Added stderr/stdout flush before program exit

### DIFF
--- a/Src/Main.cpp
+++ b/Src/Main.cpp
@@ -1814,6 +1814,8 @@ int wmain3(int argc, wchar_t** argv)
         wprintf(L"%.*s", (int)json.length(), json.data());
     }
 
+    fflush(stdout);
+    fflush(stderr);
     return programResult;
 }
 
@@ -1826,11 +1828,15 @@ int wmain2(int argc, wchar_t** argv)
     catch(const std::exception& ex)
     {
         fwprintf(stderr, L"ERROR: %hs\n", ex.what());
+        fflush(stdout);
+        fflush(stderr);
         return PROGRAM_EXIT_ERROR_EXCEPTION;
     }
     catch(...)
     {
         fwprintf(stderr, L"UNKNOWN ERROR.\n");
+        fflush(stdout);
+        fflush(stderr);
         return PROGRAM_EXIT_ERROR_EXCEPTION;
     }
 }
@@ -1844,6 +1850,8 @@ int wmain(int argc, wchar_t** argv)
     __except(EXCEPTION_EXECUTE_HANDLER)
     {
         fwprintf(stderr, L"STRUCTURED EXCEPTION: 0x%08X.\n", GetExceptionCode());
+        fflush(stdout);
+        fflush(stderr);
         return PROGRAM_EXIT_ERROR_SEH_EXCEPTION;
     }
 }


### PR DESCRIPTION
This fixes running app with output redirection
For some reason, on some computers, output done via wprintf is buffered with last chunk of output being lost
The issue is only when using output redirection, via WinAPI, or in terminal (e.g. `D3d12info.exe > info.txt`)

Alternative to this would be to use `std::cout`/`std::wcout` which seems to work perfectly fine